### PR TITLE
Fix: AttributeError when no EXPIRING_TOKEN_LIFESPAN in settings.py file

### DIFF
--- a/rest_framework_expiring_authtoken/authentication.py
+++ b/rest_framework_expiring_authtoken/authentication.py
@@ -30,7 +30,7 @@ class ExpiringTokenAuthentication(TokenAuthentication):
         if not token.user.is_active:
             raise exceptions.AuthenticationFailed('User inactive or deleted')
 
-        if token.expired():
+        if token.expiration_set() and token.expired():
             raise exceptions.AuthenticationFailed('Token has expired')
 
         return (token.user, token)

--- a/rest_framework_expiring_authtoken/models.py
+++ b/rest_framework_expiring_authtoken/models.py
@@ -27,7 +27,8 @@ class ExpiringToken(Token):
     def expiration_set(self):
         """Return boolean indicating if EXPIRING_TOKEN_LIFESPAN has been set in projects setting.py file"""
         try:
-            _ = settings.EXPIRING_TOKEN_LIFESPAN
-            return True
+            if settings.EXPIRING_TOKEN_LIFESPAN:
+                return True
+            return False
         except AttributeError:
             return False

--- a/rest_framework_expiring_authtoken/models.py
+++ b/rest_framework_expiring_authtoken/models.py
@@ -27,7 +27,7 @@ class ExpiringToken(Token):
     def expiration_set(self):
         """Return boolean indicating if EXPIRING_TOKEN_LIFESPAN has been set in projects setting.py file"""
         try:
-            settings.EXPIRING_TOKEN_LIFESPAN
+            _ = settings.EXPIRING_TOKEN_LIFESPAN
             return True
         except AttributeError:
             return False

--- a/rest_framework_expiring_authtoken/models.py
+++ b/rest_framework_expiring_authtoken/models.py
@@ -23,3 +23,11 @@ class ExpiringToken(Token):
         if self.created < now - settings.EXPIRING_TOKEN_LIFESPAN:
             return True
         return False
+
+    def expiration_set(self):
+        """Return boolean indicating if EXPIRING_TOKEN_LIFESPAN has been set in projects setting.py file"""
+        try:
+            settings.EXPIRING_TOKEN_LIFESPAN
+            return True
+        except AttributeError:
+            return False

--- a/rest_framework_expiring_authtoken/views.py
+++ b/rest_framework_expiring_authtoken/views.py
@@ -26,6 +26,10 @@ class ObtainExpiringAuthToken(ObtainAuthToken):
                 user=serializer.validated_data['user']
             )
 
+            if not token.expiration_set():
+                # If no EXPIRING_TOKEN_LIFESPAN is set in settings file, then skip checking if token is expired
+                return Response({'token': token.key})
+
             if token.expired():
                 # If the token is expired, generate a new one.
                 token.delete()


### PR DESCRIPTION
- let the token generation and authentication to happen without expiration time, like
  default DRF token authentication, if no EXPIRING_TOKEN_LIFESPAN is declared in settings file
