### PR TITLE
Test Coverage Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
 
 install:
   - pip install Django==$DJANGO_VERSION djangorestframework==3.2.3
+  - pip install coverage==3.7.1
   - pip install coveralls
 script:
   coverage run runtests.py


### PR DESCRIPTION
Fix Coverage.py at 3.7.1 to work with Python 3.2.
