### PR TITLE
authentication model missing s - issue #11

### DIFF
--- a/rest_framework_expiring_authtoken/authentication.py
+++ b/rest_framework_expiring_authtoken/authentication.py
@@ -24,7 +24,7 @@ class ExpiringTokenAuthentication(TokenAuthentication):
         """Attempt token authentication using the provided key."""
         try:
             token = self.models.objects.get(key=key)
-        except self.model.DoesNotExist:
+        except self.models.DoesNotExist:
             raise exceptions.AuthenticationFailed('Invalid token')
 
         if not token.user.is_active:

--- a/rest_framework_expiring_authtoken/authentication.py
+++ b/rest_framework_expiring_authtoken/authentication.py
@@ -18,13 +18,13 @@ class ExpiringTokenAuthentication(TokenAuthentication):
     Based on http://stackoverflow.com/questions/14567586/
     """
 
-    models = ExpiringToken
+    model = ExpiringToken
 
     def authenticate_credentials(self, key):
         """Attempt token authentication using the provided key."""
         try:
-            token = self.models.objects.get(key=key)
-        except self.models.DoesNotExist:
+            token = self.model.objects.get(key=key)
+        except self.model.DoesNotExist:
             raise exceptions.AuthenticationFailed('Invalid token')
 
         if not token.user.is_active:


### PR DESCRIPTION
as reported on issue #11 

authentication.py line 27:
except self.model.DoesNotExist: should be except self.models.DoesNotExist: note the missing s of models
