### PR TITLE
Bumped version of Django to 1.10.2 and Django Rest Framework to 3.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO_VERSION=1.8.14
-  - DJANGO_VERSION=1.9.9
+  - DJANGO_VERSION=1.8.15
+  - DJANGO_VERSION=1.9.10
   - DJANGO_VERSION=1.10.2
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
@@ -11,10 +10,6 @@ env:
   - DJANGO_VERSION=1.10.2
 matrix:
   exclude:
-    - python: "3.2"
-      env: DJANGO_VERSION=1.9.9
-    - python: "3.2"
-      env: DJANGO_VERSION=1.10.2
     - python: "3.3"
       env: DJANGO_VERSION=1.9.9
     - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,21 @@ python:
 env:
   - DJANGO_VERSION=1.8.14
   - DJANGO_VERSION=1.9.9
-  - DJANGO_VERSION=1.10.1
+  - DJANGO_VERSION=1.10.2
 matrix:
   exclude:
     - python: "3.2"
       env: DJANGO_VERSION=1.9.9
     - python: "3.2"
-      env: DJANGO_VERSION=1.10.1
+      env: DJANGO_VERSION=1.10.2
     - python: "3.3"
       env: DJANGO_VERSION=1.9.9
     - python: "3.3"
-      env: DJANGO_VERSION=1.10.1
+      env: DJANGO_VERSION=1.10.2
   fast_finish: true
 
 install:
-  - pip install Django==$DJANGO_VERSION djangorestframework==3.4.6
+  - pip install Django==$DJANGO_VERSION djangorestframework==3.5.1
   - pip install coverage==3.7.1
   - pip install coveralls
 script:

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,11 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        'djangorestframework>=3.2.3,<=3.4.6'
+        'djangorestframework>=3.2.3,<=3.5.1'
     ],
     test_suite='runtests.run',
     tests_require=[
-        'Django>=1.8.14,<=1.10.1'
+        'Django>=1.8.14,<=1.10.2'
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Hi @JamesRitchie ,

Nice bit of work here. Thanks for writing it. I'd really like to use it in my current project and I'm running Django 1.10.2 and Django Rest Framework 3.5.1. So I've just bumped those versions. 

I also bumped Django 1.8 and 1.9 minor versions to keep up with latest resleases.

Django Rest Framework doesn't seem to be compatitble with Pyhton 3.2. There's a syntax error in there. So I've removed 3.2 completely from travis build. Note Django Rest Framwork doesn't test 3.2 either https://github.com/tomchristie/django-rest-framework/blob/3.5.1/tox.ini

Thanks
