### PR TITLE
Added configurable sliding expiration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ docs/_build/
 
 # PyBuilder
 target/
+*.swp

--- a/README.md
+++ b/README.md
@@ -1,30 +1,16 @@
 # Expiring Tokens for Django Rest Framework
 
-[![Build Status](https://travis-ci.org/JamesRitchie/django-rest-framework-expiring-tokens.svg?branch=master)](https://travis-ci.org/JamesRitchie/django-rest-framework-expiring-tokens)
-[![Coverage Status](https://coveralls.io/repos/JamesRitchie/django-rest-framework-expiring-tokens/badge.svg)](https://coveralls.io/r/JamesRitchie/django-rest-framework-expiring-tokens)
-[![Code Health](https://landscape.io/github/JamesRitchie/django-rest-framework-expiring-tokens/master/landscape.svg?style=flat)](https://landscape.io/github/JamesRitchie/django-rest-framework-expiring-tokens/master)
-[![PyPI version](https://badge.fury.io/py/djangorestframework-expiring-authtoken.svg)](http://badge.fury.io/py/djangorestframework-expiring-authtoken)
-[![Requirements Status](https://requires.io/github/JamesRitchie/django-rest-framework-expiring-tokens/requirements.svg?branch=master)](https://requires.io/github/JamesRitchie/django-rest-framework-expiring-tokens/requirements/?branch=master)
+[![Build Status](https://travis-ci.org/JamesRitchie/django-rest-framework-expiring-tokens.svg?branch=master)](https://travis-ci.org/JamesRitchie/django-rest-framework-expiring-tokens) [![Coverage Status](https://coveralls.io/repos/JamesRitchie/django-rest-framework-expiring-tokens/badge.svg)](https://coveralls.io/r/JamesRitchie/django-rest-framework-expiring-tokens) [![Code Health](https://landscape.io/github/JamesRitchie/django-rest-framework-expiring-tokens/master/landscape.svg?style=flat)](https://landscape.io/github/JamesRitchie/django-rest-framework-expiring-tokens/master) [![PyPI version](https://badge.fury.io/py/djangorestframework-expiring-authtoken.svg)](http://badge.fury.io/py/djangorestframework-expiring-authtoken) [![Requirements Status](https://requires.io/github/JamesRitchie/django-rest-framework-expiring-tokens/requirements.svg?branch=master)](https://requires.io/github/JamesRitchie/django-rest-framework-expiring-tokens/requirements/?branch=master)
 
-This package provides a lightweight extension to the included token
-authentication in
-[Django Rest Framework](http://www.django-rest-framework.org/), causing tokens
-to expire after a specified duration.
+This package provides a lightweight extension to the included token authentication in [Django Rest Framework](http://www.django-rest-framework.org/), causing tokens to expire after a specified duration.
 
-This behaviour is good practice when using token authentication for production
-APIs.
-If you require more complex token functionality, you're probably better off
-looking at one of the OAuth2 implementations available for Django Rest
-Framework.
+This behaviour is good practice when using token authentication for production APIs. If you require more complex token functionality, you're probably better off looking at one of the OAuth2 implementations available for Django Rest Framework.
 
-This package was inspired by this
-[Stack Overflow answer](http://stackoverflow.com/a/15380732).
+This package was inspired by this [Stack Overflow answer](http://stackoverflow.com/a/15380732).
 
 ## Installation
 
-Expiring Tokens is tested against the latest versions of Django 1.6, 1.7 and
-the 1.8 preview release, and Django Rest Framework 3.1.1.
-It should in theory support Django 1.4.
+Expiring Tokens is tested against the latest versions of Django 1.6, 1.7 and the 1.8 preview release, and Django Rest Framework 3.1.1. It should in theory support Django 1.4.
 
 Grab the package from PyPI.
 
@@ -32,10 +18,7 @@ Grab the package from PyPI.
 pip install djangorestframework-expiring-authtoken
 ```
 
-As this package uses a proxy model on the original Token model, the first step
-is to setup the default
-[TokenAuthentication](http://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication)
-scheme, and check that it works.
+As this package uses a proxy model on the original Token model, the first step is to setup the default [TokenAuthentication](http://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication) scheme, and check that it works.
 
 Then, add the package to `INSTALLED_APPS` along with `rest_framework.authtoken` in `settings.py`.
 
@@ -49,20 +32,19 @@ INSTALLED_APPS = [
 ]
 ```
 
-Specify the desired lifespan of a token with `EXPIRING_TOKEN_LIFESPAN` in
-`settings.py` using a
-[timedelta object](https://docs.python.org/2/library/datetime.html#timedelta-objects).
-If not set, the default is 30 days.
+Specify the desired lifespan of a token with `EXPIRING_TOKEN_LIFESPAN` and the window for sliding expiration with `EXPIRING_TOKEN_SLIDE_WINDOW` in `settings.py` using a [timedelta object](https://docs.python.org/2/library/datetime.html#timedelta-objects).
+
+If not set, the default life span is 30 days. The default slide window on the other hand is 0 milliseconds. This means that token expiration shall not be readjusted even when clients are actively sending requests to the API.
 
 ```python
 import datetime
-EXPIRING_TOKEN_LIFESPAN = datetime.timedelta(days=25)
+EXPIRING_TOKEN_LIFESPAN = datetime.timedelta(minutes=30)
+EXPIRING_TOKEN_SLIDE_WINDOW = datetime.timedelta(minutes=30)
 ```
 
-[Set the authentication scheme](http://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme) to `rest_framework_expiring_authtoken.authentication.ExpiringTokenAuthentication`
-on a default or per-view basis.
+[Set the authentication scheme](http://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme) to `rest_framework_expiring_authtoken.authentication.ExpiringTokenAuthentication` on a default or per-view basis.
 
-If you used the `obtain_auth_token` view, you'll need to replace it with the  `obtain_expiring_auth_token` view in your URLconf.
+If you used the `obtain_auth_token` view, you'll need to replace it with the `obtain_expiring_auth_token` view in your URLconf.
 
 ```python
 from rest_framework_expiring_authtoken import views
@@ -71,9 +53,7 @@ urlpatterns += [
 ]
 ```
 
-If using Django 1.7 or later, you'll need to run `migrate`, even though nothing
-is changed, as Django requires proxy models that inherit from models in an
-app with migrations to also have migrations.
+If using Django 1.7 or later, you'll need to run `migrate`, even though nothing is changed, as Django requires proxy models that inherit from models in an app with migrations to also have migrations.
 
 ```zsh
 python manage.py migrate

--- a/rest_framework_expiring_authtoken/models.py
+++ b/rest_framework_expiring_authtoken/models.py
@@ -21,6 +21,10 @@ class ExpiringToken(Token):
     def expired(self):
         """Return boolean indicating token expiration."""
         now = timezone.now()
-        if self.created < now - token_settings.EXPIRING_TOKEN_LIFESPAN:
+        if self.created + token_settings.EXPIRING_TOKEN_SLIDE_WINDOW <= now - token_settings.EXPIRING_TOKEN_LIFESPAN:
             return True
+        else:
+            self.created = now
+            self.save()
+
         return False

--- a/rest_framework_expiring_authtoken/settings.py
+++ b/rest_framework_expiring_authtoken/settings.py
@@ -26,4 +26,18 @@ class TokenSettings(object):
 
         return val
 
+    @property
+    def EXPIRING_TOKEN_SLIDE_WINDOW(self):
+        """
+        Returns the time window for sliding a token's expiration.
+        Defaults to 0 milliseconds i.e. no sliding enabled.
+        """
+		
+        try:
+            val = settings.EXPIRING_TOKEN_SLIDE_WINDOW
+        except AttributeError:
+            val = timedelta(milliseconds=0)
+
+        return val
+
 token_settings = TokenSettings()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -41,5 +41,5 @@ class ExpiringTokenTestCase(TestCase):
         """Check the expired method return true for an outdated token."""
         # Crude, but necessary as auto_now_add field can't be changed.
         with self.settings(EXPIRING_TOKEN_LIFESPAN=timedelta(milliseconds=1)):
-            sleep(0.001)
+            sleep(0.003)
             self.assertTrue(self.token.expired())


### PR DESCRIPTION
Hi @JamesRitchie ,

I was able to use your work in one of the APIs I'm working on. That saved me a lot of time. Thanks a lot. I had to customize it a bit though as I couldn't allow the token to be valid for days. I introduced sliding token expiration. Yes, much like how sessions are handled in typical web applications. The thing is I'm creating an API that is mobile-ready but can also double as a web application backend.

Basically, if the token expires but a request makes it to the slide window, the token's creation time is set to the current time thereby extending the life span of the same token by another X minutes or so depending on the life span setting. Of course, you already know how this works. (:

Aside from the primary sources, I updated the tests, and a handful of lines in the README file. It could use a code review and an optimization though. Feel free to do whatever you want with this now.

Thanks!