### PR TITLE
Adding support for setting to always reset token after authenticating

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,13 @@ Specify the desired lifespan of a token with `EXPIRING_TOKEN_LIFESPAN` in
 [timedelta object](https://docs.python.org/2/library/datetime.html#timedelta-objects).
 If not set, the default is 30 days.
 
+Also there is a field called `ALWAYS_RESET_TOKEN`, which allows token to be reset everytime this is checked.
+If not set, default is False
+
 ```python
 import datetime
 EXPIRING_TOKEN_LIFESPAN = datetime.timedelta(days=25)
+ALWAYS_RESET_TOKEN = True
 ```
 
 [Set the authentication scheme](http://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme) to `rest_framework_expiring_authtoken.authentication.ExpiringTokenAuthentication`

--- a/rest_framework_expiring_authtoken/models.py
+++ b/rest_framework_expiring_authtoken/models.py
@@ -21,6 +21,6 @@ class ExpiringToken(Token):
     def expired(self):
         """Return boolean indicating token expiration."""
         now = timezone.now()
-        if self.created < now - token_settings.EXPIRING_TOKEN_LIFESPAN:
+        if (self.created < now - token_settings.EXPIRING_TOKEN_LIFESPAN) or token_settings.ALWAYS_RESET_TOKEN:
             return True
         return False

--- a/rest_framework_expiring_authtoken/settings.py
+++ b/rest_framework_expiring_authtoken/settings.py
@@ -21,8 +21,24 @@ class TokenSettings(object):
         """
         try:
             val = settings.EXPIRING_TOKEN_LIFESPAN
+
         except AttributeError:
             val = timedelta(days=30)
+
+        return val
+
+    @property
+    def ALWAYS_RESET_TOKEN(self):
+        """
+        Return if token should be reset every time at login
+
+        Defaults to False
+        """
+        try:
+            val = settings.ALWAYS_RESET_TOKEN
+
+        except AttributeError:
+            val = False
 
         return val
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -76,3 +76,15 @@ class ExpiringTokenAuthenticationTestCase(TestCase):
                 self.assertEqual(e.__str__(), 'Token has expired')
             else:
                 self.fail("AuthenticationFailed not raised.")
+
+    def test_always_reset_token(self):
+        """Check that token always expires."""
+        with self.settings(ALWAYS_RESET_TOKEN=True):
+            sleep(0.001)
+
+            try:
+                self.test_instance.authenticate_credentials(self.key)
+            except AuthenticationFailed as e:
+                self.assertEqual(e.__str__(), 'Token has expired')
+            else:
+                self.fail("AuthenticationFailed not raised.")


### PR DESCRIPTION
Hi @JamesRitchie , great work on this project. I am using it for my site, and I would like to share a little enhancement I made. I added support for always resetting token after authenticating. It is a simple ALWAYS_RESET_TOKEN setting inside django's settings.py, and is made False by default if the setting is not present. I also added a few test cases, as well as edited the documentation to reflect this. Let me know if you have any questions or concerns.