### PR TITLE
Bump versions for django and DRF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   fast_finish: true
 
 install:
-  - pip install Django==$DJANGO_VERSION djangorestframework==3.4.6
+  - pip install Django==$DJANGO_VERSION djangorestframework==3.5.4
   - pip install coverage==3.7.1
   - pip install coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
@@ -11,10 +10,6 @@ env:
   - DJANGO_VERSION=1.10.6
 matrix:
   exclude:
-    - python: "3.2"
-      env: DJANGO_VERSION=1.9.12
-    - python: "3.2"
-      env: DJANGO_VERSION=1.10.6
     - python: "3.3"
       env: DJANGO_VERSION=1.9.12
     - python: "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,19 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO_VERSION=1.8.14
-  - DJANGO_VERSION=1.9.9
-  - DJANGO_VERSION=1.10.1
+  - DJANGO_VERSION=1.8.17
+  - DJANGO_VERSION=1.9.12
+  - DJANGO_VERSION=1.10.6
 matrix:
   exclude:
     - python: "3.2"
-      env: DJANGO_VERSION=1.9.9
+      env: DJANGO_VERSION=1.9.12
     - python: "3.2"
-      env: DJANGO_VERSION=1.10.1
+      env: DJANGO_VERSION=1.10.6
     - python: "3.3"
-      env: DJANGO_VERSION=1.9.9
+      env: DJANGO_VERSION=1.9.12
     - python: "3.3"
-      env: DJANGO_VERSION=1.10.1
+      env: DJANGO_VERSION=1.10.6
   fast_finish: true
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        'djangorestframework>=3.2.3,<=3.4.6'
+        'djangorestframework>=3.2.3,<=3.5.4'
     ],
     test_suite='runtests.run',
     tests_require=[


### PR DESCRIPTION
Like #16, but bumps to newer versions. 

Also dropped python 3.2 from tests, as python 3.2 is now EOL. Also Django 1.8 doesn't test against it: 

> Due to the end of upstream support for Python 3.2 in February 2016, we won’t test Django 1.8.x on Python 3.2 after the end of 2016.