### PR TITLE
Moved import timedelta(days=30) from user settings to django-rest-framework-expiring-tokens/settings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Specify the desired lifespan of a token with `EXPIRING_TOKEN_LIFESPAN` in
 If not set, the default is 30 days.
 
 ```python
-import datetime
-EXPIRING_TOKEN_LIFESPAN = datetime.timedelta(days=25)
+# number of days
+EXPIRING_TOKEN_LIFESPAN = 25
 ```
 
 [Set the authentication scheme](http://www.django-rest-framework.org/api-guide/authentication/#setting-the-authentication-scheme) to `rest_framework_expiring_authtoken.authentication.ExpiringTokenAuthentication`

--- a/rest_framework_expiring_authtoken/settings.py
+++ b/rest_framework_expiring_authtoken/settings.py
@@ -20,7 +20,7 @@ class TokenSettings(object):
         Defaults to 30 days.
         """
         try:
-            val = settings.EXPIRING_TOKEN_LIFESPAN
+            val = timedelta(days=settings.EXPIRING_TOKEN_LIFESPAN)
         except AttributeError:
             val = timedelta(days=30)
 


### PR DESCRIPTION
moved timedelta(days=30) from user settings to rest_framework_expiring_authtoken/settings.py. So instead we import timedelta and use it inside user settings lets make things simple for consumer and set it to just EXPIRING_TOKEN_LIFESPAN = 30. 
README.MD updated accordingly .