### PR TITLE
Update test and requirements to supported versions of Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,20 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 env:
-  - DJANGO_VERSION=1.8.14
-  - DJANGO_VERSION=1.9.9
-  - DJANGO_VERSION=1.10.1
+  - DJANGO='Django<2,>=1.11' DRF='djangorestframework<3.5,>=3.4'
+  - DJANGO='Django<2,>=1.11' DRF='djangorestframework<3.6,>=3.5'
+  - DJANGO='Django<2,>=1.11' DRF='djangorestframework<3.7,>=3.6'
+  - DJANGO='Django<2,>=1.11' DRF='djangorestframework<3.8,>=3.7'
+  - DJANGO='Django<2,>=1.11' DRF='djangorestframework<3.9,>=3.8'
 matrix:
-  exclude:
-    - python: "3.2"
-      env: DJANGO_VERSION=1.9.9
-    - python: "3.2"
-      env: DJANGO_VERSION=1.10.1
-    - python: "3.3"
-      env: DJANGO_VERSION=1.9.9
-    - python: "3.3"
-      env: DJANGO_VERSION=1.10.1
   fast_finish: true
 
 install:
-  - pip install Django==$DJANGO_VERSION djangorestframework==3.4.6
+  - pip install "$DJANGO" "$DRF"
   - pip install coverage==3.7.1
   - pip install coveralls
 script:

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,11 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests*']),
     install_requires=[
-        'djangorestframework>=3.2.3,<=3.4.6'
+        'djangorestframework>=3.4'
     ],
     test_suite='runtests.run',
     tests_require=[
-        'Django>=1.8.14,<=1.10.1'
+        'Django>=1.8.14,<2'
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Run tests against maintained versions of Django, DRF, and Python

This drops support for Django versions prior to 1.11, as they are past
EOL. This tests against Django Rest Framework versions of 3.4, 3.5,
3.6, 3.7 and 3.8. And it drops tests for versions of Python that are
past EOL and adds Python 3.6.

From what I can tell, no code changes are necessary to support Django 1.11.